### PR TITLE
feat: demontrate externalized karma config

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2,16 +2,8 @@ var gulp = require('gulp');
 var _ = require('lodash');
 var karma = require('karma').server;
 
-//one could also externalize common config into a separate file,
-//ex.: var karmaCommonConf = require('./karma-common-conf.js');
-var karmaCommonConf = {
-  browsers: ['Chrome'],
-  frameworks: ['jasmine'],
-  files: [
-    'src/**/*.js',
-    'test/**/*.spec.js'
-  ]
-};
+//externalized common config into a separate file
+var karmaCommonConf = require('./karma-common-conf.js');
 
 /**
  * Run test once and exit

--- a/karma-common-conf.js
+++ b/karma-common-conf.js
@@ -1,0 +1,8 @@
+module.exports = {
+  browsers: ['Chrome'],
+  frameworks: ['jasmine'],
+  files: [
+    'src/**/*.js',
+    'test/**/*.spec.js'
+  ]
+};

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,0 +1,3 @@
+module.exports = function(config) {
+  config.set(require('./karma-common-conf.js'));
+};


### PR DESCRIPTION
The idea here is to show how to externalise common Karma config so it can be used both from Gulp as well as from other channels (command line, WebStorm integration etc.).

WDYT?
